### PR TITLE
Remove caching

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,6 @@ python-dotenv = "*"
 fastapi = "*"
 uvicorn = "*"
 pydantic = "*"
-redis = "*"
 elasticsearch = "*"
 requests-aws4auth = "*"
 

--- a/groa_ds_api/__init__.py
+++ b/groa_ds_api/__init__.py
@@ -3,7 +3,6 @@ from groa_ds_api.utils import MovieUtility
 from groa_ds_api.models import *
 import os
 from pathlib import Path
-import redis
 import pickle
 from typing import List
 from datetime import datetime

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ pytest==5.4.1
 python-dateutil==2.8.1
 python-dotenv==0.13.0
 pytz==2020.1
-redis==3.5.1
 requests==2.23.0
 requests-aws4auth==0.9
 s3transfer==0.3.3


### PR DESCRIPTION
Removes redis dependency and all caching code from `__init__.py` to remove the need to utilize ElasticCache in production. This change was made to save resources spent on keeping production up and running and with such little usage at this time does not affect performance to a noticeable degree. 